### PR TITLE
Cache owner before burning revoked assets

### DIFF
--- a/contracts/assets/AssetOwnership.sol
+++ b/contracts/assets/AssetOwnership.sol
@@ -134,9 +134,11 @@ contract AssetOwnership is
     /// @dev This action is irreversible and restricted to governance control.
     /// @param assetId The unique identifier of the asset to be revoked.
     function revoke(uint256 assetId) external restricted {
+        address previousOwner = ownerOf(assetId);
+
         _burn(assetId);
         _disableAsset(assetId);
-        emit RevokedAsset(ownerOf(assetId), assetId);
+        emit RevokedAsset(previousOwner, assetId);
     }
 
     /// @notice Transfers an asset to a new owner.


### PR DESCRIPTION
## Summary
- cache the token owner before revoking so governance can emit the correct RevokedAsset event after burning

## Testing
- `forge test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5581d3cc883308d382127acbb14f5